### PR TITLE
Make it work on macOS

### DIFF
--- a/scripts/qsh
+++ b/scripts/qsh
@@ -34,7 +34,15 @@ QSH_EDITOR=${QSH_EDITOR:-$VISUAL}
 
 # Guarantees that the output file will register as changed
 function touch_output {
-  touch -m -t "$(date -d '+1 second' +"%Y%m%d%H%M.%S")" $OUTPUT_FILE;
+  case $OSTYPE in
+    linux*)
+      TS=$(date -d '+1 second' +"%Y%m%d%H%M.%S")
+      ;;
+    darwin*)
+      TS=$(date -v+1S +"%Y%m%d%H%M.%S")
+      ;;
+  esac
+  touch -m -t "$TS" $OUTPUT_FILE;
 }
 
 # If neither pane file exists, it must mean that this is the first time we are running in this


### PR DESCRIPTION
Adds case statement to touch_output() because macOS has bsd date which uses different options.